### PR TITLE
Use .yaml extension for YAML files when possible

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,7 +7,6 @@ extends: default
 yaml-files:
   - "*.yaml"
   - "*.yml"
-  - .yamllint
 
 ignore-from-file: .gitignore
 


### PR DESCRIPTION
The YAML spec says:

> Please use ".yaml" when possible.

See https://yaml.org/faq.html

In cases where there is a pre-existing convention to use ".yml" (e.g. GitHub Actions workflows), that convention should be followed.